### PR TITLE
Fix Uninitialised string offset error: 0

### DIFF
--- a/src/QtDatabase.php
+++ b/src/QtDatabase.php
@@ -164,7 +164,7 @@ class QtDatabase
             while (!feof($stream)) {
                 $line = trim(fgets($stream), "\t\n\r\0");
                 if ('--' != substr($line, 0, 2)) {
-                    if ('' != $statement && ' ' != substr($statement, -1) && ' ' != $line[0]) {
+                    if ('' != $statement && ' ' != substr($statement, -1) && $line && ' ' != $line[0]) {
                         $statement .= ' ';
                     }
                     $statement .= $line;


### PR DESCRIPTION
This error occurs when $line = '' and we are trying to access $line[0].

![Screenshot from 2019-09-25 09-39-45](https://user-images.githubusercontent.com/25319264/65568745-86ac0200-df78-11e9-9e9d-6d30086b2931.png)
